### PR TITLE
Added priority property support in main config.toml

### DIFF
--- a/Source/DivaModLoader/Config.cpp
+++ b/Source/DivaModLoader/Config.cpp
@@ -2,11 +2,11 @@
 
 bool Config::enableDebugConsole;
 std::string Config::modsDirectoryPath;
+std::vector<std::string> Config::priorityPaths;
 
 bool Config::init()
 {
     toml::table config;
-
     try
     {
         config = toml::parse_file("config.toml");
@@ -24,6 +24,16 @@ bool Config::init()
 
     enableDebugConsole = config["console"].value_or(false);
     modsDirectoryPath = config["mods"].value_or("mods");
+
+    if (toml::array* priorityArr = config["priority"].as_array())
+    {
+        for (auto& pathElem : *priorityArr)
+        {
+            const std::string path = pathElem.value_or("");
+            if (!path.empty())
+                priorityPaths.push_back(path);
+        }
+    }
 
     return true;
 }

--- a/Source/DivaModLoader/Config.h
+++ b/Source/DivaModLoader/Config.h
@@ -5,6 +5,7 @@ class Config
 public:
     static bool enableDebugConsole;
     static std::string modsDirectoryPath;
+    static std::vector<std::string> priorityPaths;
 
     static bool init();
 };

--- a/Source/DivaModLoader/ModLoader.cpp
+++ b/Source/DivaModLoader/ModLoader.cpp
@@ -90,12 +90,25 @@ void ModLoader::init()
 {
     LOG("Mods: \"%s\"", getRelativePath(Config::modsDirectoryPath).c_str())
 
-    for (auto& modDirectory : std::filesystem::directory_iterator(Config::modsDirectoryPath))
+    if (Config::priorityPaths.size() > 0)
     {
-        if (std::filesystem::is_directory(modDirectory))
-            initMod(modDirectory.path());
+        LOG("Using priority array")
+        for (auto& path : Config::priorityPaths)
+        {
+            const std::string modDirectory = Config::modsDirectoryPath + "\\" + path;
+            if (std::filesystem::is_directory(modDirectory))
+                initMod(modDirectory);
+        }
     }
-
+    else
+    {
+        LOG("Using alphanumeric folder name order for priority")
+        for (auto& modDirectory : std::filesystem::directory_iterator(Config::modsDirectoryPath))
+        {
+            if (std::filesystem::is_directory(modDirectory))
+                initMod(modDirectory.path());
+        }
+    }
     if (!modDirectoryPaths.empty())
         INSTALL_HOOK(InitRomDirectoryPaths);
 }


### PR DESCRIPTION
Added basic support for mod order priority without needing to rename mod folders. Mods are loaded in order of priority array given in the main config.toml. If the priority property doesn't exist in the config.toml, the load order defaults back to alphanumeric naming order. Thought that this would make it easier for future mod manager support to manage priority (editing config.toml instead of renaming folders in alphanumeric order).

Example:
`priority = ["Restore Cut Songs", "High Refresh Rate"]`

![image](https://user-images.githubusercontent.com/70003922/171798619-067a0722-20df-4fc0-9727-5aa068f45595.png)
